### PR TITLE
Update files to be ignored and use shallow cloning

### DIFF
--- a/semgrep_rules_manager/data/sources.yaml
+++ b/semgrep_rules_manager/data/sources.yaml
@@ -6,6 +6,8 @@ community:
     # YAML files that are not rules.
     - stats
     - template.yaml
+    - .pre-commit-config.yaml
+    - .github
   author: Semgrep
   license: LGPL 2.1
 gitlab:
@@ -15,6 +17,9 @@ gitlab:
   ignored:
     # YAML files that are not rules.
     - mappings
+    - .gitlab-ci.yml
+    - ci
+    - qa
     # Invalid rules
     - java/scaffold.yml
     - scala/scaffold.yml
@@ -26,6 +31,9 @@ trailofbits:
   description: Rules used in the audits, research, and projects of Trail of Bits
   repository_url: https://github.com/trailofbits/semgrep-rules
   repository_branch: main
+  ignored:
+    # YAML files that are not rules
+    - .github
   author: Trail of Bits
   license: AGPL-3.0
 "0xdea":
@@ -41,6 +49,8 @@ elttam:
   ignored:
     # YAML files that are not rules.
     - perf-templates
+    - .pre-commit-config.yaml
+    - .github
   author: elttam
   license: MIT
 kondukto:
@@ -48,12 +58,12 @@ kondukto:
   repository_url: https://github.com/kondukto-io/semgrep-rules
   repository_branch: master
   author: Kondukto
-  license: 
+  license:
 dgryski:
   description: Custom Go rules
   repository_url: https://github.com/dgryski/semgrep-go
   repository_branch: master
-  author: Damian Gryski 
+  author: Damian Gryski
   license: MIT
 dotta:
   description: Rules developed while doing pentest on web and mobile apps

--- a/semgrep_rules_manager/sources.py
+++ b/semgrep_rules_manager/sources.py
@@ -102,7 +102,7 @@ class Source:
         return repo.rev_parse("origin/" + self.repo_brach).hexsha
 
     def download(self) -> None:
-        git.Repo.clone_from(self.repo_url, self.location)
+        git.Repo.clone_from(self.repo_url, self.location,multi_options=['--depth=1'])
 
         self._preprocess()
         self._remove_ignored()


### PR DESCRIPTION
This pull req fixes #1 using the proposed fix.

I've also added a small optimization to the cloning by using shallow cloning so that it only gets the most recent files and not the full repo history. Currently this reduces the full rules folder by 16MB, not big impact for desktop users but a good improvement for when rules manager is used in CI or Github Actions.